### PR TITLE
fix for a small bug in image size in older iOS versions

### DIFF
--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -48,6 +48,9 @@
     }
     float scaleFactor = scaledHeight / sourceHeight;
     
+	DebugLog(@"%@", [NSNumber numberWithBool:cropping]);
+	DebugLog(@"%f %f", scaledWidth, scaledHeight);
+	
     // Calculate compositing rectangles
     CGRect sourceRect, destRect;
     if (cropping) {
@@ -103,7 +106,7 @@
 	if (!image) {
 		// Try older method.
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-		CGContextRef context = CGBitmapContextCreate(NULL, fitSize.width, fitSize.height, 8, (fitSize.width * 4), 
+		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (fitSize.width * 4), 
 													 colorSpace, kCGImageAlphaPremultipliedLast);
 		CGImageRef sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect);
 		CGContextDrawImage(context, destRect, sourceImg);

--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -103,7 +103,7 @@
 	if (!image) {
 		// Try older method.
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (fitSize.width * 4), 
+		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (scaledWidth * 4), 
 													 colorSpace, kCGImageAlphaPremultipliedLast);
 		CGImageRef sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect);
 		CGContextDrawImage(context, destRect, sourceImg);

--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -48,9 +48,6 @@
     }
     float scaleFactor = scaledHeight / sourceHeight;
     
-	DebugLog(@"%@", [NSNumber numberWithBool:cropping]);
-	DebugLog(@"%f %f", scaledWidth, scaledHeight);
-	
     // Calculate compositing rectangles
     CGRect sourceRect, destRect;
     if (cropping) {


### PR DESCRIPTION
Hi there, 

There is a small bug in UIImage category, 
For older iOS versions, scaling down creates image with wrong size.
For example, I was trying to fit an image into 200x200 square on iPad (3.2.2) and instead of image with 122x200  pixels in size I was always getting 200x200 which is wrong.

one line fix in my commit ;)

Thanks,
Marcin
