### PR TITLE
Fix warning in Xcode 4.6

### DIFF
--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -52,7 +52,7 @@
 	CGRect sourceRect, destRect;
 	if (cropping) {
 		destRect = CGRectMake(0, 0, targetWidth, targetHeight);
-		float destX, destY;
+		float destX = 0.0f, destY = 0.0f;
 		if (resizeMethod == MGImageResizeCrop) {
 			// Crop center
 			destX = round((scaledWidth - targetWidth) / 2.0);

--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -89,9 +89,9 @@
 	
 	// Create appropriately modified image.
 	UIImage *image = nil;
+	CGImageRef sourceImg = nil;
 	
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
-	CGImageRef sourceImg = nil;
 	if ([UIScreen instancesRespondToSelector:@selector(scale)]) {
 		UIGraphicsBeginImageContextWithOptions(destRect.size, NO, 0.f); // 0.f for scale means "scale for device's main screen".
 		sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect); // cropping happens here.
@@ -114,7 +114,7 @@
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (scaledWidth * 4), 
 													 colorSpace, kCGImageAlphaPremultipliedLast);
-		CGImageRef sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect);
+		sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect);
 		CGContextDrawImage(context, destRect, sourceImg);
 		CGImageRelease(sourceImg);
 		CGImageRef finalImage = CGBitmapContextCreateImage(context);	


### PR DESCRIPTION
In Xcode 4.6, there is now an uninitialized variable warning. Even though it is logically impossible for the variables to be uninitialized, Xcode no longer realizes it. Setting them to 0 fixes it.
