### PR TITLE
Keep opaque on resize

### DIFF
--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -93,7 +93,9 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 	CGImageRef sourceImg = nil;
 	if ([UIScreen instancesRespondToSelector:@selector(scale)]) {
-		UIGraphicsBeginImageContextWithOptions(destRect.size, NO, 0.f); // 0.f for scale means "scale for device's main screen".
+		CGImageAlphaInfo alpha = CGImageGetAlphaInfo([self CGImage]);
+		BOOL hasAlpha = (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast);
+		UIGraphicsBeginImageContextWithOptions(destRect.size, !hasAlpha, 0.f); // 0.f for scale means "scale for device's main screen".
 		sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect); // cropping happens here.
 		image = [UIImage imageWithCGImage:sourceImg scale:0.0 orientation:self.imageOrientation]; // create cropped UIImage.
 		

--- a/Classes/UIImage+ProportionalFill.m
+++ b/Classes/UIImage+ProportionalFill.m
@@ -114,8 +114,10 @@
 	if (!image) {
 		// Try older method.
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (scaledWidth * 4), 
-													 colorSpace, kCGImageAlphaPremultipliedLast);
+		CGImageAlphaInfo alpha = CGImageGetAlphaInfo([self CGImage]);
+		BOOL hasAlpha = (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast);
+		CGContextRef context = CGBitmapContextCreate(NULL, scaledWidth, scaledHeight, 8, (scaledWidth * 4),
+													 colorSpace, hasAlpha ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNoneSkipLast);
 		CGImageRef sourceImg = CGImageCreateWithImageInRect([self CGImage], sourceRect);
 		CGContextDrawImage(context, destRect, sourceImg);
 		CGImageRelease(sourceImg);


### PR DESCRIPTION
I needed to test if a resized UIImage was opaque or not to know if I could safely store it in JPEG format (photo) or I should use PNG (image with alpha mask).

Resizing an UIImage always resulted in an UIImage with an alpha channel, so everything was always stored as PNG.

This fix my problem.
